### PR TITLE
Updated error showing and keyboard behaviour

### DIFF
--- a/passwordGenerator03/App.tsx
+++ b/passwordGenerator03/App.tsx
@@ -1,4 +1,4 @@
-import { SafeAreaView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
+import { SafeAreaView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View, Keyboard } from 'react-native'
 import React, { useState } from 'react'
 
 import BouncyCheckbox from "react-native-bouncy-checkbox";
@@ -101,7 +101,7 @@ export default function App() {
          <View style={styles.inputWrapper}>
           <View style={styles.inputColumn}>
             <Text style={styles.heading}>Password Length</Text>
-            {touched.passwordLength && errors.passwordLength && (
+            {errors.passwordLength && (
               <Text style={styles.errorText}>
                 {errors.passwordLength}
               </Text>
@@ -156,7 +156,10 @@ export default function App() {
           <TouchableOpacity
           disabled={!isValid}
           style={styles.primaryBtn}
-          onPress={handleSubmit}
+          onPress={ () => {
+            handleSubmit();
+            Keyboard.dismiss();
+          }}
           >
             <Text style={styles.primaryBtnTxt}>Generate Password</Text>
           </TouchableOpacity>
@@ -228,6 +231,7 @@ const styles = StyleSheet.create({
     borderColor: '#16213e',
   },
   errorText: {
+    width: 200,
     fontSize: 12,
     color: '#ff0d10',
   },


### PR DESCRIPTION
Hi, don't want to be published on readme, but thought these changes necessary. The .min and .max error messages of yup passwordSchema was not showing. So I removed touched.passwordLength and it worked for me.  Moreover, these long error messages was pushing textInput field out of view so I added width: 200 to styles.errorText and it worked nicely. Moreover, keyboard wasn't hiding automatically when I clicked Generate Password so I added Keyboard.dismiss() from the react native Keyboard module. After addition, it started working nicely.